### PR TITLE
This change modifies the backend application to use a local SQLite da…

### DIFF
--- a/app/backend/README.md
+++ b/app/backend/README.md
@@ -26,16 +26,23 @@ This document provides instructions on how to set up and run the backend applica
     ```
 
 4.  **Set Environment Variables:**
-    You need to configure the `SUPABASE_DB_URL` environment variable. This URL is provided by your Supabase project.
+
+    ### Database Configuration
+
+    **Local Development (Default: SQLite)**
+
+    For local development, the application is configured to use a SQLite database by default. The database file (`local.db`) will be created automatically in the `app/backend` directory when you run migrations or start the application if it doesn't already exist. No specific environment variables are required for this default setup.
+
+    **Using a PostgreSQL Database (e.g., Supabase - Optional)**
+
+    If you prefer to use a PostgreSQL database (like one hosted on Supabase), you can set the `SUPABASE_DB_URL` environment variable. If this variable is set, it will override the default SQLite configuration.
+
     *   **Finding your Supabase Database URL:**
         1.  Go to your Supabase project dashboard.
         2.  Navigate to **Project Settings** (the gear icon).
         3.  Click on **Database** in the sidebar.
         4.  Under **Connection string**, find the string that starts with `postgresql://postgres:[YOUR-PASSWORD]@[AWS-REGION].supabase.co:[PORT]/postgres`. Use this entire string.
-
     *   **Setting the Environment Variable:**
-        You can set this variable in your shell, in a `.env` file (if the application is configured to load it - typically using a library like `python-dotenv`, which is not currently listed in requirements, so manual export is safer), or through your deployment environment's configuration.
-
         Example (for bash/zsh):
         ```bash
         export SUPABASE_DB_URL="your_supabase_connection_string_here"
@@ -43,10 +50,11 @@ This document provides instructions on how to set up and run the backend applica
         Ensure this variable is set in the terminal session where you run the application.
 
 5.  **Run Database Migrations:**
-    The backend uses Alembic to manage database migrations. After setting up your `SUPABASE_DB_URL`, run the following command from the `app/backend` directory to apply any pending migrations:
+    The backend uses Alembic to manage database migrations. After setting up your database configuration, run the following command from the `app/backend` directory to apply any pending migrations:
     ```bash
     alembic upgrade head
     ```
+    For the default SQLite setup, if the `local.db` file does not exist, this command (or running the application) will create it automatically. If you are using `SUPABASE_DB_URL`, ensure the database is created on the server before running migrations.
     If you are setting up the database for the first time, this will create all the necessary tables.
 
 6.  **Run the Application:**

--- a/app/backend/alembic.ini
+++ b/app/backend/alembic.ini
@@ -84,7 +84,7 @@ path_separator = os
 # database URL.  This is consumed by the user-maintained env.py script only.
 # other means of configuring database URLs may be customized within the env.py
 # file.
-sqlalchemy.url = postgresql://env_var_should_replace_this/db
+sqlalchemy.url = sqlite:///./local.db
 
 
 [post_write_hooks]

--- a/app/backend/alembic/env.py
+++ b/app/backend/alembic/env.py
@@ -15,13 +15,6 @@ from app.models import User, Profile, Experience, Education
 # access to the values within the .ini file in use.
 config = context.config
 
-# Set the sqlalchemy.url in the Alembic config object if not already set by alembic.ini
-# This ensures that env.py uses the same URL as defined in database.py,
-# especially if alembic.ini is not perfectly synced or for programmatic configuration.
-# However, the primary source should be alembic.ini as configured earlier.
-if not config.get_main_option("sqlalchemy.url"):
-    config.set_main_option("sqlalchemy.url", DATABASE_URL)
-
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
@@ -69,12 +62,12 @@ def run_migrations_online() -> None:
 
     """
     # Fetch DB_URL from environment variable or alembic.ini
-    DB_URL = os.getenv('SUPABASE_DB_URL', config.get_main_option("sqlalchemy.url"))
+    actual_db_url = DATABASE_URL # This is imported from app.database at the top of the file
 
     # If using engine_from_config, ensure it uses the fetched DB_URL.
     # Create a new dictionary for engine configuration or update existing one.
     engine_config = config.get_section(config.config_ini_section, {})
-    engine_config['sqlalchemy.url'] = DB_URL  # Override with SUPABASE_DB_URL if available
+    engine_config['sqlalchemy.url'] = actual_db_url  # Override with SUPABASE_DB_URL if available
 
     connectable = engine_from_config(
         engine_config,  # Use the modified config

--- a/app/backend/app/database.py
+++ b/app/backend/app/database.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import sessionmaker
 # Consider using environment variables for this.
 # Example for PostgreSQL: "postgresql://user:password@host:port/dbname"
 # Example for SQLite (for local development): "sqlite:///./test.db"
-DATABASE_URL = os.environ.get("SUPABASE_DB_URL", "postgresql://user:password@localhost/profileappdb") # FIXME: Placeholder, user must configure
+DATABASE_URL = os.environ.get("SUPABASE_DB_URL", "sqlite:///./local.db") # FIXME: Placeholder, user must configure
 
 engine = create_engine(DATABASE_URL)
 


### PR DESCRIPTION
…tabase (`local.db`) by default for development, simplifying the initial setup process.

Key changes:
- `app/database.py`: Default `DATABASE_URL` changed to `sqlite:///./local.db`. It still respects `SUPABASE_DB_URL` if set.
- `alembic.ini`: `sqlalchemy.url` updated to `sqlite:///./local.db` for migrations.
- `alembic/env.py`: Refactored to directly use `DATABASE_URL` from `app.database`, ensuring consistency between the application and Alembic migrations, especially when `SUPABASE_DB_URL` is or isn't set.
- `README.md`: Updated to reflect the new default SQLite setup, explaining that the database file is created automatically and how to optionally use `SUPABASE_DB_URL` for a PostgreSQL database.

This addresses the issue of Supabase connection problems by providing a simpler local alternative and clarifies that manual database creation is not needed for the default SQLite setup.