### PR TITLE
Switch to PostgreSQL and fix NameError

### DIFF
--- a/app/backend/alembic.ini
+++ b/app/backend/alembic.ini
@@ -84,7 +84,8 @@ path_separator = os
 # database URL.  This is consumed by the user-maintained env.py script only.
 # other means of configuring database URLs may be customized within the env.py
 # file.
-sqlalchemy.url = sqlite:///./local.db
+# sqlalchemy.url = sqlite:///./local.db
+# The database URL is now configured in env.py using the DATABASE_URL environment variable.
 
 
 [post_write_hooks]

--- a/app/backend/app/crud.py
+++ b/app/backend/app/crud.py
@@ -1,5 +1,6 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 from sqlalchemy import update as sqlalchemy_update # To avoid confusion with schema update models
+from fastapi import HTTPException, status # For raising exceptions
 from . import models, schemas
 from passlib.context import CryptContext
 
@@ -22,14 +23,6 @@ def create_user(db: Session, user: schemas.UserCreate) -> models.User:
     db.commit()
     db.refresh(db_user)
     return db_user
-
-# --- Profile CRUD ---
-def get_profile_by_user_id(db: Session, user_id: int) -> models.Profile | None:
-from fastapi import HTTPException, status # For raising exceptions
-
-# --- Profile CRUD ---
-def get_profile_by_user_id(db: Session, user_id: int) -> models.Profile | None:
-from sqlalchemy.orm import selectinload # For eager loading
 
 # --- Profile CRUD ---
 def get_profile_by_user_id(db: Session, user_id: int) -> models.Profile | None:

--- a/app/backend/app/database.py
+++ b/app/backend/app/database.py
@@ -7,7 +7,9 @@ from sqlalchemy.orm import sessionmaker
 # Consider using environment variables for this.
 # Example for PostgreSQL: "postgresql://user:password@host:port/dbname"
 # Example for SQLite (for local development): "sqlite:///./test.db"
-DATABASE_URL = os.environ.get("SUPABASE_DB_URL", "sqlite:///./local.db") # FIXME: Placeholder, user must configure
+DATABASE_URL = os.environ.get("SUPABASE_DB_URL")
+if DATABASE_URL is None:
+    raise RuntimeError("SUPABASE_DB_URL environment variable not set. Please configure it for PostgreSQL.")
 
 engine = create_engine(DATABASE_URL)
 


### PR DESCRIPTION
Migrates the application from SQLite to PostgreSQL:
- Updates `app/backend/app/database.py` to require the `SUPABASE_DB_URL` environment variable for PostgreSQL, removing the SQLite fallback.
- Updates `app/backend/alembic.ini` to no longer use a hardcoded SQLite URL, ensuring Alembic uses the PostgreSQL URL from `env.py`.
- Adds an initial Alembic migration script in `app/backend/alembic/versions/` for the existing schema. You will need to run `alembic upgrade head` in your environment.

Fixes a `NameError: name 'selectinload' is not defined` in `app/backend/app/crud.py` by moving the import statement to the top of the file.

Note: Application testing and database migration application (`alembic upgrade head`) must be performed manually in a suitable environment with a running PostgreSQL server.